### PR TITLE
prereq-build: Add detection for python 3.13

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -187,6 +187,7 @@ $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
 $(eval $(call SetupHostCommand,python,Please install Python >= 3.7, \
+	python3.13 -V 2>&1 | grep 'Python 3', \
 	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \
 	python3.10 -V 2>&1 | grep 'Python 3', \
@@ -196,6 +197,7 @@ $(eval $(call SetupHostCommand,python,Please install Python >= 3.7, \
 	python3 -V 2>&1 | grep -E 'Python 3\.([7-9]|[0-9][0-9])\.?'))
 
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.7, \
+	python3.13 -V 2>&1 | grep 'Python 3', \
 	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \
 	python3.10 -V 2>&1 | grep 'Python 3', \


### PR DESCRIPTION
Debian 13 "Trixie" includes Python 3.13.
Then you know what's the story.
